### PR TITLE
Fix Sky import so game renders correctly

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://unpkg.com/three@0.157.0/build/three.module.js';
-import { Sky } from 'https://unpkg.com/three@0.157.0/examples/jsm/objects/Sky.js';
+import { Sky } from 'https://unpkg.com/three@0.157.0/examples/jsm/objects/Sky.js?module';
 
 // --- Renderer & Scene ---
 const canvas = document.getElementById('game');


### PR DESCRIPTION
## Summary
- Ensure the Three.js Sky helper imports with `?module` so its dependency on `three` resolves, allowing the scene (and car) to render

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b214dfc84833385ddc694b847b2f0